### PR TITLE
Include project composer file only if it exists

### DIFF
--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,5 +1,10 @@
 <?php
-include_once __DIR__.'/../../../autoload.php'; //autoload from main composer autoloader
+
+$file = __DIR__ . '/../../../autoload.php';
+if (file_exists($file)) {
+    include_once $file; //autoload from main composer autoloader
+}
+
 error_reporting(E_ALL | E_STRICT);
 chdir(__DIR__);
 


### PR DESCRIPTION
If tests suite is executed in sabas/edifact lib, project Composer file does not
exists and Composer autoload is already required.

Fix #55