### PR TITLE
Fix documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ OR
 $c = new Parser($x);
 
 $r = new Reader();
-$r->setParsedFile($c);
+$r->setParsedFile($c->get());
 $sender = $r->readEdiDataValue('UNB', 2);
 $Dt = $r->readUNBDateTimeOfPreperation();
 ```

--- a/src/EDI/Reader.php
+++ b/src/EDI/Reader.php
@@ -64,7 +64,7 @@ class Reader {
      * @param $parsed_file array
      * @return bool
      */
-    public function setParsedFile($parsed_file) {
+    public function setParsedFile(array $parsed_file) {
         $this->parsedfile = $parsed_file;
         return $this->preValidate();
     }


### PR DESCRIPTION
I tried this code and get nothing:

```php
$path = 'path/to/vali/edi/file';
$parser = new Parser();
$parser->load($path);

$reader = new Reader();
$reader->setParsedFile($parser);

var_dump($reader->readUNHmessageNumber());
```

I had to use `$reader->setParsedFile($parser->get());`

I put an array type hinting on `Reader::setParsedFile` method but I do not know if someone use Traversables with this method.