### PR TITLE
bumb version of voku/Arrayy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "php": ">=7.0.0",
         "ext-simplexml": "*",
         "ext-json": "*",
-        "voku/arrayy": "5.5.*"
+        "voku/arrayy": "5.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",


### PR DESCRIPTION
https://github.com/voku/Arrayy#installation-via-composer-manually

removes abandoned dependency to array_column from voku/Arrayy 5.5.0