### PR TITLE
\EDI\Reader::splitMultiMessage() did a strpos on an undefinded var

### DIFF
--- a/src/EDI/Reader.php
+++ b/src/EDI/Reader.php
@@ -120,6 +120,7 @@ class Reader
         $splicedMessages = [];
         $message = [];
         $unb = false;
+        $segment = '';
 
         foreach (self::unwrap($ediMessage) as $segment) {
 


### PR DESCRIPTION
Is the if-part `if (\strpos($segment, 'UNZ') === 0) {` suppose to be inside or after the loop?

Got a warning that `$segment` may be undefined if the loop didn't loop.
So initized it to empty string.

If the code shold be inside the loop, move it, if not, apply this PR to avoid the undefined varaible case.