### PR TITLE
Fix license in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Tools in PHP for UN/EDIFACT",
     "keywords": ["EDI", "EDIFACT", "message", "container"],
     "homepage": "https://github.com/php-edifact/edifact",
-    "license": "LGPL-3.0+",
+    "license": "LGPL-3.0-or-later",
     "authors": [
         {
             "name": "Stefano Sabatini",


### PR DESCRIPTION
As per the [`composer.json` specification](https://getcomposer.org/doc/04-schema.md#license) the license should be a proper identifier from the [SPDX License List](https://spdx.org/licenses/). For LGPL 3.0+ the proper identifier is `LGPL-3.0-or-later`.