### PR TITLE
Load service segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ codeCoverage/*
 /vendor
 /build
 composer.lock
+.vscode
+.phan

--- a/src/EDI/Analyser.php
+++ b/src/EDI/Analyser.php
@@ -93,27 +93,28 @@ class Analyser
      * convert segment definition from XML to array. Sequence of data_elements and
      * composite_data_element same as in XML
      *
-     * @param string $segment_xml_file
+     * @param string $segmentXmlFile
+     * @param bool $discardOldSegments
      *
      * @return array|false
      */
-    public function loadSegmentsXml(string $segment_xml_file)
+    public function loadSegmentsXml(string $segmentXmlFile, bool $discardOldSegments = true)
     {
-        // reset
-        $this->segments = [];
+        if ($discardOldSegments) {
+            $this->segments = [];
+        }
 
-        $segments_xml = \file_get_contents($segment_xml_file);
-        if ($segments_xml === false) {
+        $segmentsXml = \file_get_contents($segmentXmlFile);
+        if ($segmentsXml === false) {
             return false;
         }
 
-        $xml = \simplexml_load_string($segments_xml);
+        $xml = \simplexml_load_string($segmentsXml);
         if ($xml === false) {
             return false;
         }
-
         // free memory
-        $segments_xml = null;
+        unset($segmentsXml);
 
         foreach ($xml as $segmentNode) {
             \assert($segmentNode instanceof \SimpleXMLElement);
@@ -131,6 +132,24 @@ class Analyser
                 $segment['details'] = $details;
             }
             $this->segments[$qualifier] = $segment;
+        }
+
+        return $this->segments;
+    }
+
+    /**
+     * Load segment definitions from multiple files
+     *
+     * @see Analyser::loadSegmentsXml()
+     * @param string[] $segmentXmlFiles
+     * @return array|false
+     */
+    public function loadMultiSegmentsXml(array $segmentXmlFiles)
+    {
+        foreach ($segmentXmlFiles as $xmlFile) {
+            if (!$result = $this->loadSegmentsXml($xmlFile)) {
+                return $result;
+            }
         }
 
         return $this->segments;

--- a/tests/EDITest/InterpreterTest.php
+++ b/tests/EDITest/InterpreterTest.php
@@ -18,7 +18,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
-        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments(3));
+        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments('3'));
 
         $interpreter = new Interpreter($mapping->getMessage('COARRI'), $segs, $svc);
         /** @noinspection UnusedFunctionResultInspection */
@@ -36,7 +36,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
-        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments(3));
+        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments('3'));
 
         $interpreter = new Interpreter($mapping->getMessage('COARRI'), $segs, $svc);
         /** @noinspection UnusedFunctionResultInspection */
@@ -55,7 +55,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
-        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments(3));
+        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments('3'));
 
         $interpreter = new Interpreter($mapping->getMessage('BAPLIE'), $segs, $svc);
         /** @noinspection UnusedFunctionResultInspection */
@@ -75,16 +75,15 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $mapping = new \EDI\Mapping\MappingProvider('D96A');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
-        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments(3));
+        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments('3'));
 
         $interpreter = new Interpreter($mapping->getMessage('DESADV'), $segs, $svc);
         /** @noinspection UnusedFunctionResultInspection */
         $interpreter->prepare($parser->get());
 
-        $json = $interpreter->getJson(true);
         static::assertJsonStringEqualsJsonFile(
             __DIR__ . '/../files/D96ADESADV.json',
-            $json,
+            $interpreter->getJson(true),
             'JSON does not match expected output'
         );
 
@@ -104,7 +103,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
-        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments(3));
+        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments('3'));
 
         $interpreter = new Interpreter($mapping->getMessage('BAPLIE'), $segs, $svc);
         /** @noinspection UnusedFunctionResultInspection */
@@ -125,7 +124,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
-        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments(3));
+        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments('3'));
 
         $interpreter = new Interpreter($mapping->getMessage('ORDERS'), $segs, $svc);
         /** @noinspection UnusedFunctionResultInspection */
@@ -170,7 +169,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
-        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments(3));
+        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments('3'));
 
         $interpreter = new Interpreter($mapping->getMessage('ORDERS'), $segs, $svc);
         /** @noinspection UnusedFunctionResultInspection */
@@ -205,7 +204,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
-        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments(3));
+        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments('3'));
 
         $interpreter = new Interpreter($mapping->getMessage('BAPLIE'), $segs, $svc);
         /** @noinspection UnusedFunctionResultInspection */
@@ -226,10 +225,10 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
-        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments(3));
+        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments('3'));
 
         $interpreter = new Interpreter($mapping->getMessage('BAPLIE'), $segs, $svc);
-        $p = $interpreter->prepare($parser->get());
+        $interpreter->prepare($parser->get());
         $errors = $interpreter->getErrors();
         $svcSegs = $interpreter->getServiceSegments();
         static::assertCount(0, $errors);
@@ -243,7 +242,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $mapping = new \EDI\Mapping\MappingProvider($parser->getMessageDirectory());
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
-        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments(3));
+        $svc = $analyser->loadSegmentsXml($mapping->getServiceSegments('3'));
 
         $interpreter = new Interpreter($mapping->getMessage($parser->getMessageFormat()), $segs, $svc);
         $interpreter->toggleUseIdInsteadOfNameForOutput(true);

--- a/tests/EDITest/InterpreterTest.php
+++ b/tests/EDITest/InterpreterTest.php
@@ -45,7 +45,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         $svcjson = $interpreter->getJsonServiceSegments();
         $svcjsonpretty = $interpreter->getJsonServiceSegments(true);
         static::assertSame($svc, \json_decode($svcjson, true));
-        static::assertSame(26, \substr_count($svcjsonpretty, "\n"));
+        static::assertSame(28, \substr_count($svcjsonpretty, "\n"));
     }
 
     public function testBAPLIE()
@@ -81,14 +81,15 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         /** @noinspection UnusedFunctionResultInspection */
         $interpreter->prepare($parser->get());
 
+        $json = $interpreter->getJson(true);
         static::assertJsonStringEqualsJsonFile(
             __DIR__ . '/../files/D96ADESADV.json',
-            $interpreter->getJson(true),
+            $json,
             'JSON does not match expected output'
         );
 
-        static::assertSame(3152, \strlen($interpreter->getJson()));
-        static::assertSame(8379, \strlen($interpreter->getJson(true)));
+        static::assertSame(3598, \strlen($interpreter->getJson()));
+        static::assertSame(9383, \strlen($interpreter->getJson(true)));
 
         static::assertCount(2, $interpreter->getMessages());
         static::assertCount(0, $interpreter->getErrors());
@@ -157,7 +158,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
 
         $arrayy = $interpreter->getArrayyServiceSegments();
         static::assertCount(
-            13,
+            14,
             $arrayy->get('interchangeHeader')
         );
     }
@@ -192,7 +193,7 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
 
         $arrayy = $interpreter->getArrayyServiceSegments();
         static::assertCount(
-            13,
+            14,
             $arrayy->get('interchangeHeader')
         );
     }

--- a/tests/EDITest/ParserTest.php
+++ b/tests/EDITest/ParserTest.php
@@ -96,8 +96,8 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
 
     public function testFileOk()
     {
+        $errors = [];
         $string = \file_get_contents(__DIR__ . '/../files/example_order_ok.edi');
-
         for ($i = 0; $i < 100; ++$i) { // keep for simple performance tests
             $errors = (new Parser($string))->errors();
         }
@@ -149,7 +149,7 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
     {
         $string = ["EQD+CX'DU12?+3456+2?:0'", "EQD+CXDU12?+3456+2?:0'"];
         $p = new Parser();
-        $result = $p->parse($string);
+        $p->parse($string);
         $experror = "There's a ' not escaped in the data; string EQD+CX'DU12?+3456+2?:0";
         $error = $p->errors();
         static::assertContains($experror, $error);

--- a/tests/EDITest/ReaderTest.php
+++ b/tests/EDITest/ReaderTest.php
@@ -27,13 +27,13 @@ final class ReaderTest extends \PHPUnit\Framework\TestCase
 
     public function testReadUNBDateTimeOfPpreperation()
     {
-        $Dt = (new Reader(__DIR__ . '/../files/example.edi'))->readUNBDateTimeOfPpreperation();
+        $Dt = (new Reader(__DIR__ . '/../files/example.edi'))->readUNBDateTimeOfPreparation();
         static::assertSame('2094-01-01 09:50:00', $Dt);
     }
 
     public function testReadUNBDateTimeOfPreperation()
     {
-        $Dt = (new Reader(__DIR__ . '/../files/example.edi'))->readUNBDateTimeOfPreperation();
+        $Dt = (new Reader(__DIR__ . '/../files/example.edi'))->readUNBDateTimeOfPreparation();
         static::assertSame('2094-01-01 09:50:00', $Dt);
     }
 

--- a/tests/files/D96ADESADV.json
+++ b/tests/files/D96ADESADV.json
@@ -1,214 +1,235 @@
 [
-   {
-      "messageHeader":{
-         "segmentIdx":0,
-         "segmentCode":"UNH",
-         "messageReferenceNumber":"142",
-         "messageIdentifier":{
-            "messageType":"DESADV",
-            "messageVersionNumber":"0",
-            "messageReleaseNumber":"96A",
-            "controllingAgency":"UN"
-         }
-      },
-      "beginningOfMessage":{
-         "segmentIdx":1,
-         "segmentCode":"BGM",
-         "documentmessageName":{
-            "documentmessageNameCoded":"351"
-         },
-         "documentmessageNumber":"Y02197250",
-         "messageFunctionCoded":"700101"
-      },
-      "datetimeperiod":{
-         "segmentIdx":2,
-         "segmentCode":"DTM",
-         "datetimeperiod":{
-            "datetimeperiodQualifier":"11",
-            "datetimeperiod":"20160726",
-            "datetimeperiodFormatQualifier":"102"
-         }
-      },
-      "SG1":[
-         {
-            "reference":{
-               "segmentIdx":3,
-               "segmentCode":"RFF",
-               "reference":{
-                  "referenceQualifier":"ON",
-                  "referenceNumber":"6877871"
-               }
+    {
+        "messageHeader": {
+            "segmentIdx": 0,
+            "segmentCode": "UNH",
+            "segmentGroup": "",
+            "messageReferenceNumber": "142",
+            "messageIdentifier": {
+                "messageType": "DESADV",
+                "messageVersionNumber": "0",
+                "messageReleaseNumber": "96A",
+                "controllingAgency": "UN"
             }
-         },
-         {
-            "reference":{
-               "segmentIdx":4,
-               "segmentCode":"RFF",
-               "reference":{
-                  "referenceQualifier":"PK",
-                  "referenceNumber":"VEE0214439"
-               }
-            }
-         }
-      ],
-      "SG2":[
-         {
-            "nameAndAddress":{
-               "segmentIdx":5,
-               "segmentCode":"NAD",
-               "partyQualifier":"SU",
-               "partyIdentificationDetails":{
-                  "partyIdIdentification":"1694901"
-               },
-               "nameAndAddress":{
-                  "nameAndAddressLine":"31B"
-               }
-            }
-         },
-         {
-            "nameAndAddress":{
-               "segmentIdx":6,
-               "segmentCode":"NAD",
-               "partyQualifier":"BY",
-               "partyIdentificationDetails":{
-                  "partyIdIdentification":"01131116"
-               },
-               "nameAndAddress":{
-                  "nameAndAddressLine":"31B"
-               }
-            }
-         }
-      ],
-      "SG10":[
-         {
-            "consignmentPackingSequence":{
-               "segmentIdx":7,
-               "segmentCode":"CPS",
-               "hierarchicalIdNumber":"IE2156580387"
+        },
+        "beginningOfMessage": {
+            "segmentIdx": 1,
+            "segmentCode": "BGM",
+            "segmentGroup": "",
+            "documentmessageName": {
+                "documentmessageNameCoded": "351"
             },
-            "SG15":[
-               {
-                  "lineItem":{
-                     "segmentIdx":8,
-                     "segmentCode":"LIN",
-                     "lineItemNumber":"001"
-                  },
-                  "additionalProductId":{
-                     "segmentIdx":9,
-                     "segmentCode":"PIA",
-                     "productIdFunctionQualifier":"5",
-                     "itemNumberIdentification":{
-                        "itemNumber":"9780738507330"
-                     }
-                  },
-                  "itemDescription":{
-                     "segmentIdx":10,
-                     "segmentCode":"IMD",
-                     "itemDescriptionTypeCoded":"F",
-                     "itemCharacteristicCoded":"81",
-                     "itemDescription":{
-                        "itemDescriptionIdentification":"",
-                        "codeListQualifier":"",
-                        "codeListResponsibleAgencyCoded":"",
-                        "itemDescription":"MUNCIE THE MIDDLE"
-                     }
-                  },
-                  "quantity":{
-                     "segmentIdx":11,
-                     "segmentCode":"QTY",
-                     "quantityDetails":{
-                        "quantityQualifier":"12",
-                        "quantity":"1"
-                     }
-                  },
-                  "SG16":[
-                     {
-                        "reference":{
-                           "segmentIdx":12,
-                           "segmentCode":"RFF",
-                           "reference":{
-                              "referenceQualifier":"LI",
-                              "referenceNumber":"6877871"
-                           }
-                        }
-                     },
-                     {
-                        "reference":{
-                           "segmentIdx":13,
-                           "segmentCode":"RFF",
-                           "reference":{
-                              "referenceQualifier":"ON",
-                              "referenceNumber":"6877871"
-                           }
-                        }
-                     }
-                  ]
-               },
-               {
-                  "lineItem":{
-                     "segmentIdx":14,
-                     "segmentCode":"LIN",
-                     "lineItemNumber":"002"
-                  },
-                  "additionalProductId":{
-                     "segmentIdx":15,
-                     "segmentCode":"PIA",
-                     "productIdFunctionQualifier":"5",
-                     "itemNumberIdentification":{
-                        "itemNumber":"9781568361871"
-                     }
-                  },
-                  "itemDescription":{
-                     "segmentIdx":16,
-                     "segmentCode":"IMD",
-                     "itemDescriptionTypeCoded":"F",
-                     "itemCharacteristicCoded":"81",
-                     "itemDescription":{
-                        "itemDescriptionIdentification":"",
-                        "codeListQualifier":"",
-                        "codeListResponsibleAgencyCoded":"",
-                        "itemDescription":"ROADS TO SATA A 2"
-                     }
-                  },
-                  "quantity":{
-                     "segmentIdx":17,
-                     "segmentCode":"QTY",
-                     "quantityDetails":{
-                        "quantityQualifier":"12",
-                        "quantity":"1"
-                     }
-                  },
-                  "SG16":[
-                     {
-                        "reference":{
-                           "segmentIdx":18,
-                           "segmentCode":"RFF",
-                           "reference":{
-                              "referenceQualifier":"LI",
-                              "referenceNumber":"6905456"
-                           }
-                        }
-                     },
-                     {
-                        "reference":{
-                           "segmentIdx":19,
-                           "segmentCode":"RFF",
-                           "reference":{
-                              "referenceQualifier":"ON",
-                              "referenceNumber":"6905456"
-                           }
-                        }
-                     }
-                  ]
-               }
-            ]
-         }
-      ],
-      "messageTrailer":{
-         "segmentIdx":20,
-         "segmentCode":"UNT",
-         "numberOfSegmentsInTheMessage":"21",
-         "messageReferenceNumber":"142"
-      }
-   }
+            "documentmessageNumber": "Y02197250",
+            "messageFunctionCoded": "700101"
+        },
+        "datetimeperiod": {
+            "segmentIdx": 2,
+            "segmentCode": "DTM",
+            "segmentGroup": "",
+            "datetimeperiod": {
+                "datetimeperiodQualifier": "11",
+                "datetimeperiod": "20160726",
+                "datetimeperiodFormatQualifier": "102"
+            }
+        },
+        "SG1": [
+            {
+                "reference": {
+                    "segmentIdx": 3,
+                    "segmentCode": "RFF",
+                    "segmentGroup": "SG1",
+                    "reference": {
+                        "referenceQualifier": "ON",
+                        "referenceNumber": "6877871"
+                    }
+                }
+            },
+            {
+                "reference": {
+                    "segmentIdx": 4,
+                    "segmentCode": "RFF",
+                    "segmentGroup": "SG1",
+                    "reference": {
+                        "referenceQualifier": "PK",
+                        "referenceNumber": "VEE0214439"
+                    }
+                }
+            }
+        ],
+        "SG2": [
+            {
+                "nameAndAddress": {
+                    "segmentIdx": 5,
+                    "segmentCode": "NAD",
+                    "segmentGroup": "SG2",
+                    "partyQualifier": "SU",
+                    "partyIdentificationDetails": {
+                        "partyIdIdentification": "1694901"
+                    },
+                    "nameAndAddress": {
+                        "nameAndAddressLine": "31B"
+                    }
+                }
+            },
+            {
+                "nameAndAddress": {
+                    "segmentIdx": 6,
+                    "segmentCode": "NAD",
+                    "segmentGroup": "SG2",
+                    "partyQualifier": "BY",
+                    "partyIdentificationDetails": {
+                        "partyIdIdentification": "01131116"
+                    },
+                    "nameAndAddress": {
+                        "nameAndAddressLine": "31B"
+                    }
+                }
+            }
+        ],
+        "SG10": [
+            {
+                "consignmentPackingSequence": {
+                    "segmentIdx": 7,
+                    "segmentCode": "CPS",
+                    "segmentGroup": "SG10",
+                    "hierarchicalIdNumber": "IE2156580387"
+                },
+                "SG15": [
+                    {
+                        "lineItem": {
+                            "segmentIdx": 8,
+                            "segmentCode": "LIN",
+                            "segmentGroup": "SG15",
+                            "lineItemNumber": "001"
+                        },
+                        "additionalProductId": {
+                            "segmentIdx": 9,
+                            "segmentCode": "PIA",
+                            "segmentGroup": "SG15",
+                            "productIdFunctionQualifier": "5",
+                            "itemNumberIdentification": {
+                                "itemNumber": "9780738507330"
+                            }
+                        },
+                        "itemDescription": {
+                            "segmentIdx": 10,
+                            "segmentCode": "IMD",
+                            "segmentGroup": "SG15",
+                            "itemDescriptionTypeCoded": "F",
+                            "itemCharacteristicCoded": "81",
+                            "itemDescription": {
+                                "itemDescriptionIdentification": "",
+                                "codeListQualifier": "",
+                                "codeListResponsibleAgencyCoded": "",
+                                "itemDescription": "MUNCIE THE MIDDLE"
+                            }
+                        },
+                        "quantity": {
+                            "segmentIdx": 11,
+                            "segmentCode": "QTY",
+                            "segmentGroup": "SG15",
+                            "quantityDetails": {
+                                "quantityQualifier": "12",
+                                "quantity": "1"
+                            }
+                        },
+                        "SG16": [
+                            {
+                                "reference": {
+                                    "segmentIdx": 12,
+                                    "segmentCode": "RFF",
+                                    "segmentGroup": "SG16",
+                                    "reference": {
+                                        "referenceQualifier": "LI",
+                                        "referenceNumber": "6877871"
+                                    }
+                                }
+                            },
+                            {
+                                "reference": {
+                                    "segmentIdx": 13,
+                                    "segmentCode": "RFF",
+                                    "segmentGroup": "SG16",
+                                    "reference": {
+                                        "referenceQualifier": "ON",
+                                        "referenceNumber": "6877871"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "lineItem": {
+                            "segmentIdx": 14,
+                            "segmentCode": "LIN",
+                            "segmentGroup": "SG15",
+                            "lineItemNumber": "002"
+                        },
+                        "additionalProductId": {
+                            "segmentIdx": 15,
+                            "segmentCode": "PIA",
+                            "segmentGroup": "SG15",
+                            "productIdFunctionQualifier": "5",
+                            "itemNumberIdentification": {
+                                "itemNumber": "9781568361871"
+                            }
+                        },
+                        "itemDescription": {
+                            "segmentIdx": 16,
+                            "segmentCode": "IMD",
+                            "segmentGroup": "SG15",
+                            "itemDescriptionTypeCoded": "F",
+                            "itemCharacteristicCoded": "81",
+                            "itemDescription": {
+                                "itemDescriptionIdentification": "",
+                                "codeListQualifier": "",
+                                "codeListResponsibleAgencyCoded": "",
+                                "itemDescription": "ROADS TO SATA A 2"
+                            }
+                        },
+                        "quantity": {
+                            "segmentIdx": 17,
+                            "segmentCode": "QTY",
+                            "segmentGroup": "SG15",
+                            "quantityDetails": {
+                                "quantityQualifier": "12",
+                                "quantity": "1"
+                            }
+                        },
+                        "SG16": [
+                            {
+                                "reference": {
+                                    "segmentIdx": 18,
+                                    "segmentCode": "RFF",
+                                    "segmentGroup": "SG16",
+                                    "reference": {
+                                        "referenceQualifier": "LI",
+                                        "referenceNumber": "6905456"
+                                    }
+                                }
+                            },
+                            {
+                                "reference": {
+                                    "segmentIdx": 19,
+                                    "segmentCode": "RFF",
+                                    "segmentGroup": "SG16",
+                                    "reference": {
+                                        "referenceQualifier": "ON",
+                                        "referenceNumber": "6905456"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "messageTrailer": {
+            "segmentIdx": 20,
+            "segmentCode": "UNT",
+            "segmentGroup": "SG16",
+            "numberOfSegmentsInTheMessage": "21",
+            "messageReferenceNumber": "142"
+        }
+    }
 ]


### PR DESCRIPTION
Using the Analyser I found no way to load the Service segments and message segments without overwriting the first one:

```php
$mapping  = new MappingProvider($messageType);
$analyser->loadSegmentsXml($mapping->getServiceSegments());
$analyser->loadSegmentsXml($mapping->getSegments()); //overrides the service segments
```
With the patch:

````php
$mapping  = new MappingProvider($messageType);
$analyser->loadMultiSegmentsXml([$mapping->getServiceSegments(), $mapping->getSegments()]);
````


