### PR TITLE
`voku\arrayy` in dev requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,14 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": "~8",
         "ext-json": "*",
         "ext-simplexml": "*"
     },
     "require-dev": {
         "php-edifact/edifact-mapping": "dev-master",
-        "phpunit/phpunit": "~6.0"
+        "phpunit/phpunit": "~9.0",
+        "voku/arrayy": "~7.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     "require": {
         "php": ">=7.0.0",
         "ext-json": "*",
-        "ext-simplexml": "*",
-        "voku/arrayy": "~7.1"
+        "ext-simplexml": "*"
     },
     "require-dev": {
         "php-edifact/edifact-mapping": "dev-master",

--- a/src/EDI/Interpreter.php
+++ b/src/EDI/Interpreter.php
@@ -262,6 +262,16 @@ class Interpreter
     }
 
     /**
+     * Get EDI groups.
+     *
+     * @return array
+     */
+    public function getEdiGroups()
+    {
+        return $this->ediGroups;
+    }
+
+    /**
      * Get errors
      *
      * @return array

--- a/src/EDI/Interpreter.php
+++ b/src/EDI/Interpreter.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace EDI;
 
-use Arrayy\Arrayy;
-
 /**
  * EDIFACT Messages Interpreter
  * (c) 2018 Stefano Sabatini
@@ -264,16 +262,6 @@ class Interpreter
     }
 
     /**
-     * Get result as Arrayy Object.
-     *
-     * @return Arrayy<mixed,mixed>
-     */
-    public function getArrayy()
-    {
-        return new Arrayy($this->ediGroups);
-    }
-
-    /**
      * Get errors
      *
      * @return array
@@ -317,16 +305,6 @@ class Interpreter
         }
 
         return \json_encode($this->serviceSeg);
-    }
-
-    /**
-     * Get service segments as Arrayy Object.
-     *
-     * @return Arrayy<mixed,mixed>
-     */
-    public function getArrayyServiceSegments()
-    {
-        return new Arrayy($this->serviceSeg);
     }
 
     /**

--- a/tests/EDITest/AnalyserTest.php
+++ b/tests/EDITest/AnalyserTest.php
@@ -22,7 +22,7 @@ final class AnalyserTest extends TestCase
      */
     protected $mapping;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->analyser = new Analyser();
         $this->mapping = new MappingProvider('D07A');

--- a/tests/EDITest/InterpreterTest.php
+++ b/tests/EDITest/InterpreterTest.php
@@ -149,17 +149,17 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         static::assertContains('"messageHeader"', $interpreter->getJson(true));
         static::assertContains('"interchangeHeader"', $interpreter->getJsonServiceSegments(true));
 
-        $arrayy = $interpreter->getArrayy();
-        static::assertSame(
-            'Butter 40x250g Alu',
-            $arrayy->get('0.SG25.0.itemDescription.itemDescription.itemDescription')
-        );
+        // $arrayy = $interpreter->getArrayy();
+        // static::assertSame(
+        //     'Butter 40x250g Alu',
+        //     $arrayy->get('0.SG25.0.itemDescription.itemDescription.itemDescription')
+        // );
 
-        $arrayy = $interpreter->getArrayyServiceSegments();
-        static::assertCount(
-            14,
-            $arrayy->get('interchangeHeader')
-        );
+        // $arrayy = $interpreter->getArrayyServiceSegments();
+        // static::assertCount(
+        //     14,
+        //     $arrayy->get('interchangeHeader')
+        // );
     }
 
     public function testOrderOk()
@@ -184,17 +184,17 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
         static::assertContains('"messageHeader"', $interpreter->getJson(true));
         static::assertContains('"interchangeHeader"', $interpreter->getJsonServiceSegments(true));
 
-        $arrayy = $interpreter->getArrayy();
-        static::assertSame(
-            'Butter 40x250g Alu',
-            $arrayy->get('0.SG25.0.itemDescription.itemDescription.itemDescription')
-        );
+        // $arrayy = $interpreter->getArrayy();
+        // static::assertSame(
+        //     'Butter 40x250g Alu',
+        //     $arrayy->get('0.SG25.0.itemDescription.itemDescription.itemDescription')
+        // );
 
-        $arrayy = $interpreter->getArrayyServiceSegments();
-        static::assertCount(
-            14,
-            $arrayy->get('interchangeHeader')
-        );
+        // $arrayy = $interpreter->getArrayyServiceSegments();
+        // static::assertCount(
+        //     14,
+        //     $arrayy->get('interchangeHeader')
+        // );
     }
 
     public function testMissingUNBUNH()

--- a/tests/EDITest/InterpreterTest.php
+++ b/tests/EDITest/InterpreterTest.php
@@ -2,9 +2,10 @@
 
 namespace EDITest;
 
-use EDI\Analyser;
-use EDI\Interpreter;
 use EDI\Parser;
+use EDI\Analyser;
+use Arrayy\Arrayy;
+use EDI\Interpreter;
 
 /**
  * @internal
@@ -146,20 +147,20 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
 
         static::assertCount(2, $interpreter->getMessages());
 
-        static::assertContains('"messageHeader"', $interpreter->getJson(true));
-        static::assertContains('"interchangeHeader"', $interpreter->getJsonServiceSegments(true));
+        $this->assertStringContainsString('"messageHeader"', $interpreter->getJson(true));
+        static::assertStringContainsString('"interchangeHeader"', $interpreter->getJsonServiceSegments(true));
 
-        // $arrayy = $interpreter->getArrayy();
-        // static::assertSame(
-        //     'Butter 40x250g Alu',
-        //     $arrayy->get('0.SG25.0.itemDescription.itemDescription.itemDescription')
-        // );
+        $arrayy = new Arrayy($interpreter->getEdiGroups());
+        static::assertSame(
+            'Butter 40x250g Alu',
+            $arrayy->get('0.SG25.0.itemDescription.itemDescription.itemDescription')
+        );
 
-        // $arrayy = $interpreter->getArrayyServiceSegments();
-        // static::assertCount(
-        //     14,
-        //     $arrayy->get('interchangeHeader')
-        // );
+        $arrayy =  new Arrayy($interpreter->getServiceSegments());
+        static::assertCount(
+            14,
+            $arrayy->get('interchangeHeader')
+        );
     }
 
     public function testOrderOk()
@@ -181,20 +182,20 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
 
         static::assertCount(2, $interpreter->getMessages());
 
-        static::assertContains('"messageHeader"', $interpreter->getJson(true));
-        static::assertContains('"interchangeHeader"', $interpreter->getJsonServiceSegments(true));
+        static::assertStringContainsString('"messageHeader"', $interpreter->getJson(true));
+        static::assertStringContainsString('"interchangeHeader"', $interpreter->getJsonServiceSegments(true));
 
-        // $arrayy = $interpreter->getArrayy();
-        // static::assertSame(
-        //     'Butter 40x250g Alu',
-        //     $arrayy->get('0.SG25.0.itemDescription.itemDescription.itemDescription')
-        // );
+        $arrayy = new Arrayy($interpreter->getEdiGroups());
+        static::assertSame(
+            'Butter 40x250g Alu',
+            $arrayy->get('0.SG25.0.itemDescription.itemDescription.itemDescription')
+        );
 
-        // $arrayy = $interpreter->getArrayyServiceSegments();
-        // static::assertCount(
-        //     14,
-        //     $arrayy->get('interchangeHeader')
-        // );
+        $arrayy =  new Arrayy($interpreter->getServiceSegments());
+        static::assertCount(
+            14,
+            $arrayy->get('interchangeHeader')
+        );
     }
 
     public function testMissingUNBUNH()

--- a/tests/EDITest/ParserTest.php
+++ b/tests/EDITest/ParserTest.php
@@ -104,9 +104,9 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
         static::assertSame([], $errors);
 
         $data = \json_encode((new Parser($string))->get());
-        static::assertContains('Sup 1:10', $data);
-        static::assertNotContains('Konzentrat:o', $data);
-        static::assertContains('"Rindfleischsuppe Konzentrat","o', $data);
+        static::assertStringContainsString('Sup 1:10', $data);
+        static::assertStringNotContainsString('Konzentrat:o', $data);
+        static::assertStringContainsString('"Rindfleischsuppe Konzentrat","o', $data);
     }
 
     public function testFileError()


### PR DESCRIPTION
- Update to php 8
- Update to phpunit 9
- Add Voku\Arrayy only in dev requirement (prevent `Symfony\Serializer` component regression)