### PR TITLE
Encoding check and restructured file loading

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -5,45 +5,48 @@ Load a message and dump a json
 Loading from file:
 ```php
 use EDI\Parser;
-$fn = "example.edi"; //it's a path!
-$p = new EDI\Parser($fn);
+$filePath = "example.edi";
+$p = new EDI\Parser();
+$p->load($filePath)->parse();
+$p->checkEncoding(); // optional
 if (count($p->errors()) > 0) {
 	echo json_encode($p->errors());
 	return;
 }
 echo json_encode($p->get());
 ```
-Same example works for ```$fn``` containing a wrapped string (seg'seg) or an array ([seg,seg])
+To load a single-line string (`"seg'seg"`) use `$p->loadString()`.   
+To load an array of lines (`["seg","seg"]`) use `$p->loadArray()`.
 
 Convert a formatted array to EDIFACT message
 --------------------------------------------
-Loading from a php array:
+Loading from a PHP array:
 ```php
 use EDI\Encoder;
 $arr = []; //array
-$p = new EDI\Encoder($arr, false); //one segment per line
-echo $p->get();
+$enc = new EDI\Encoder($arr, false); //one segment per line
+echo $enc->get();
 ```
 
-Create from EDI file readable file with comments
-------------------------------------------------
+Create human-readable file with comments from EDI file
+------------------------------------------------------
 
 ```php
-$fileName = 'demo.edi';
+$filePath = 'demo.edi';
 $parser = new EDI\Parser();
-$parsed = $parser->load($fileName);
+$parser->load($filePath);
 $segments = $parser->getRawSegments();
 
 $analyser = new EDI\Analyser();
 $analyser->loadSegmentsXml('edifact/src/EDI/Mapping/d95b/segments.xml');
 
-$text = $analyser->process($parsed, $segments);
+$text = $analyser->process($parsed, $parser->get());
 ```
 
 EDI data reading from extracted group
 -------------------------------------
 
-As not to have to go through the indexes for extracted groups, just set the group as ParsedFile of the reader.
+As not to have to go through the indexes for extracted groups, just use a reader with a different parser.
 
 E.g. inventory messages (snippet, not a valid EDI message!):
 
@@ -56,16 +59,18 @@ INV+1++11'QTY+156:100:PCE'QTY+145:2300:PCE'LOC+18+YA:::567'DTM+179:20180510:102'
 ```
 
 ```php
-$reader = new EDI\Reader($fileName);
-$recordReader = EDI\Reader();
+$parser = new EDI\Parser();
+$parser->load($filePath);
+$reader = new EDI\Reader($parser);
 $groups = $reader->groupsExtract('INV');
 
 foreach ($groups as $record) {
-    $recordReader->setParsedFile($record);
+    $parser->loadArray($record);
+    $r = EDI\Reader($parser);
     $records[] = [
-        'storageLocation' => $recordReader->readEdiDataValue(['LOC', ['2.0' => 'YA']], 2, 3),
-        'bookingDate' => $recordReader->readEdiSegmentDTM(179),
-        'enteredOn' => $recordReader->readEdiSegmentDTM(171),
+        'storageLocation' => $r->readEdiDataValue(['LOC', ['2.0' => 'YA']], 2, 3),
+        'bookingDate' => $r->readEdiSegmentDTM(179),
+        'enteredOn' => $r->readEdiSegmentDTM(171),
         'quantity' => $r->readEdiDataValue(['QTY', ['1.0' => 156]], 1, 1),
         'actualStock' => $r->readEdiDataValue(['QTY', ['1.0' => 145]], 1, 1)
     ];
@@ -120,11 +125,13 @@ UNB - InterchangeHeader
 ```
 
 EDI data element reading
------------------
+------------------------
 
 ```php
-$fileName = 'files/truck_out_176699.edi';
-$reader = new EDI\Reader($fileName);
+$filePath = 'files/truck_out_176699.edi';
+$parser = new EDI\Parser();
+$parser->load($filePath);
+$reader = new EDI\Reader($parser);
 
 $record = [
 	'interchangeSender' => $reader->readEdiDataValue('UNB', 2),

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "require": {
         "php": "~8",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "ext-simplexml": "*"
     },
     "require-dev": {

--- a/src/EDI/Analyser.php
+++ b/src/EDI/Analyser.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace EDI;
 
 /**
- * EDIFACT Messages Parser
+ * EDIFACT Messages Analyser
  * (c)2016 Uldis Nelsons
  */
 class Analyser

--- a/src/EDI/Parser.php
+++ b/src/EDI/Parser.php
@@ -137,7 +137,7 @@ class Parser
     public function parse(): void
     {
         $i = 0;
-        foreach ($this->rawSegments as $line) {
+        foreach ($this->getRawSegments() as $line) {
             ++$i;
 
             // Null byte and carriage return removal. (CR+LF)
@@ -250,6 +250,8 @@ class Parser
         if (\count($line) < 3) {
             return;
         }
+
+        $this->messageNumber = $line[1];
 
         $lineElement = $line[2];
         if (!\is_array($lineElement)) {

--- a/src/EDI/Parser.php
+++ b/src/EDI/Parser.php
@@ -293,6 +293,9 @@ class Parser
      */
     public function get(): array
     {
+        if (empty($this->parsedfile)) {
+            $this->parse();
+        }
         return $this->parsedfile;
     }
 
@@ -326,7 +329,7 @@ class Parser
 	 * @param string $txt
 	 * @return self
 	 */
-    public function loadString(string &$txt): self
+    public function loadString(string $txt): self
     {
 	    $this->rawSegments = $this->unwrap($txt);
 

--- a/src/EDI/Parser.php
+++ b/src/EDI/Parser.php
@@ -11,9 +11,9 @@ namespace EDI;
 class Parser
 {
     /**
-     * @var array|string[]|null
+     * @var array|string[]
      */
-    private $rawSegments;
+    private $rawSegments = [];
 
     /**
      * @var array
@@ -36,67 +36,67 @@ class Parser
     private static $DELIMITER = '/';
 
     /**
-     * @var string|null : component separator character (default \:)
+     * @var string Component separator character
      */
-    private $sepComp;
+    private $sepComp = "\:";
 
     /**
-     * @var string|null : component separator character (default :)
+     * @var string Component separator character
      */
-    private $sepUnescapedComp;
+    private $sepUnescapedComp = ':';
 
     /**
-     * @var string|null : data separator character (default \+)
+     * @var string Data separator character
      */
-    private $sepData;
+    private $sepData = "\+";
 
     /**
-     * @var string|null : dec separator character (no use but here) (default .)
+     * @var string Dec separator character (no use but here)
      */
-    private $sepDec;
+    private $sepDec = '.';
 
     /**
-     * @var string|null : release character (default \?)
+     * @var string Release character
      */
-    private $symbRel;
+    private $symbRel = "\?";
 
     /**
-     * @var string|null (default ?)
+     * @var string (default ?)
      */
-    private $symbUnescapedRel;
+    private $symbUnescapedRel = '?';
 
     /**
-     * @var string|null : repetition character (no use but here) (default *)
+     * @var string Repetition character (no use but here)
      */
-    private $symbRep;
+    private $symbRep = '*';
 
     /**
-     * @var string|null : end character (default ')
+     * @var string End character
      */
-    private $symbEnd;
+    private $symbEnd = "'";
 
     /**
-     * @var string|null : safe string (default §SS§)
+     * @var string Safe string
      */
-    private $stringSafe;
+    private $stringSafe = '§SS§';
 
     /**
-     * @var string|null Syntax identifier (default UNOB)
+     * @var string|null Syntax identifier
      */
-    private $syntaxID;
+    private $syntaxID = 'UNOB';
 
     /**
-     * @var string|null : message format from UNH
+     * @var string|null Message format from UNH
      */
     private $messageFormat;
 
     /**
-     * @var string : message directory
+     * @var string Message directory
      */
     private $messageDirectory;
 
     /**
-     * @var string : message number
+     * @var string Message number
      */
     private $messageNumber;
 
@@ -122,20 +122,14 @@ class Parser
     ];
 
     /**
-     * @var bool : TRUE when UNA's characters are known, FALSE when they are not. NULL means no initialization
+     * @var bool TRUE when UNA characters are known.
      */
-    private $unaChecked;
+    private $unaChecked = false;
 
     /**
-     * @var bool : TRUE when UNB encoding is known, FALSE when it's not. NULL means no initialization
+     * @var bool TRUE when UNB encoding is known.
      */
-    private $unbChecked;
-
-    public function __construct()
-    {
-        $this->resetUNA();
-        $this->resetUNB();
-    }
+    private $unbChecked = false;
 
     /**
      * Parse EDI array.
@@ -193,10 +187,8 @@ class Parser
     }
 
     /**
-     * Read UNA's characters definition
-     *
-     * @param string $line : UNA definition line (without UNA tag). Example : :+.? '
-     *
+     * Read UNA's characters definition.
+     * @param string $line UNA definition line (without UNA tag). Example : :+.? '
      * @return void
      */
     public function analyseUNA(string $line)
@@ -226,10 +218,8 @@ class Parser
     }
 
     /**
-     * UNB line analysis
-     *
+     * UNB line analysis.
      * @param string|string[] $line UNB definition line (without UNB tag). Example UNOA:2
-     *
      * @return void
      */
     public function analyseUNB($line): void
@@ -251,10 +241,8 @@ class Parser
     }
 
     /**
-     * Identify message type
-     *
+     * Identify message type.
      * @param array<mixed|string> $line UNH segment
-     *
      * @return void
      */
     public function analyseUNH(array $line): void
@@ -276,7 +264,6 @@ class Parser
 
     /**
      * Check if the encoding of the text actually matches the one declared by the UNB syntax identifier.
-     *
      * @return bool
      * @throws \RuntimeException
      */
@@ -292,8 +279,7 @@ class Parser
     }
 
     /**
-     * Get errors
-     *
+     * Get errors.
      * @return array
      */
     public function errors(): array
@@ -302,8 +288,7 @@ class Parser
     }
 
     /**
-     * Get parsed lines/segments
-     *
+     * Get parsed lines/segments.
      * @return array
      */
     public function get(): array
@@ -312,11 +297,10 @@ class Parser
     }
 
     /**
-     * Get raw segments array
-     *
-     * @return array|string[]|null
+     * Get raw segments array.
+     * @return array|string[]
      */
-    public function getRawSegments()
+    public function getRawSegments(): array
     {
         return $this->rawSegments;
     }
@@ -365,9 +349,7 @@ class Parser
 
     /**
      * Change the default regex used for stripping invalid characters.
-     *
      * @param string $regex
-     *
      * @return void
      */
     public function setStripRegex(string $regex)
@@ -401,42 +383,9 @@ class Parser
         return $this->messageNumber;
     }
 
-
     /**
-     * Reset UNA's characters definition
-     *
-     * @return void
-     */
-    private function resetUNA()
-    {
-        $this->sepComp = "\:";
-        $this->sepUnescapedComp = ':';
-        $this->sepData = "\+";
-        $this->sepDec = '.'; // See later if a preg_quote is needed
-        $this->symbRel = "\?";
-        $this->symbUnescapedRel = '?';
-        $this->symbRep = '*'; // See later if a preg_quote is needed
-        $this->symbEnd = "'";
-        $this->stringSafe = '§SS§';
-        $this->unaChecked = false;
-    }
-
-    /**
-     * Reset UNB's encoding definition
-     *
-     * @return void
-     */
-    private function resetUNB()
-    {
-        $this->syntaxID = 'UNOB';
-        $this->unbChecked = false;
-    }
-
-    /**
-     * Unwrap string splitting rows on terminator (if not escaped)
-     *
+     * Unwrap string splitting rows on terminator (if not escaped).
      * @param string $string
-     *
      * @return string[]
      */
     private function unwrap(string &$string): array
@@ -497,10 +446,8 @@ class Parser
     }
 
     /**
-     * Segments
-     *
+     * Split segment.
      * @param string $str
-     *
      * @return array|string[]
      */
     private function splitSegment(string &$str): array
@@ -572,10 +519,8 @@ class Parser
     }
 
     /**
-     * Composite data element
-     *
+     * Composite data element.
      * @param string $str
-     *
      * @return mixed
      */
     private function splitData(string &$str)

--- a/src/EDI/Parser.php
+++ b/src/EDI/Parser.php
@@ -134,7 +134,7 @@ class Parser
     /**
      * Parse EDI array.
      */
-    public function parse(): void
+    public function parse(): self
     {
         $i = 0;
         foreach ($this->getRawSegments() as $line) {
@@ -184,6 +184,7 @@ class Parser
                     break;
             }
         }
+        return $this;
     }
 
     /**
@@ -333,6 +334,8 @@ class Parser
 	 */
     public function loadString(string $txt): self
     {
+        $this->resetUNA();
+        $this->resetUNB();
 	    $this->rawSegments = $this->unwrap($txt);
 
         return $this;
@@ -345,6 +348,8 @@ class Parser
 	 */
 	public function loadArray(array $lines): self
 	{
+        $this->resetUNA();
+        $this->resetUNB();
         $this->rawSegments = $lines;
         if (\count($lines) === 1) {
 			$this->loadString($lines[0]);
@@ -386,6 +391,34 @@ class Parser
     public function getMessageNumber()
     {
         return $this->messageNumber;
+    }
+
+    /**
+     * Reset UNA character definition to defaults.
+     * @return void
+     */
+    private function resetUNA(): void
+    {
+        $this->sepComp = "\:";
+        $this->sepUnescapedComp = ':';
+        $this->sepData = "\+";
+        $this->sepDec = '.'; // See later if a preg_quote is needed
+        $this->symbRel = "\?";
+        $this->symbUnescapedRel = '?';
+        $this->symbRep = '*'; // See later if a preg_quote is needed
+        $this->symbEnd = "'";
+        $this->stringSafe = '§SS§';
+        $this->unaChecked = false;
+    }
+
+    /**
+     * Reset UNB encoding definition to defaults.
+     * @return void
+     */
+    private function resetUNB(): void
+    {
+        $this->syntaxID = 'UNOB';
+        $this->unbChecked = false;
     }
 
     /**

--- a/src/EDI/Reader.php
+++ b/src/EDI/Reader.php
@@ -63,15 +63,15 @@ class Reader
     }
 
     /**
-     * @param string $url url to edi file, path to edi file or EDI message
-     *
+     * @param string $location URL or path to EDI file/message
      * @return bool
      */
-    public function load(string $url): bool
+    public function load(string $location): bool
     {
-        $this->parsedfile = (new Parser($url))->get();
+        $parser = new Parser();
+        $parser->load($location)->parse();
 
-        return $this->preValidate();
+        return $this->setParsedFile($parser->get());
     }
 
     /**

--- a/src/EDI/Reader.php
+++ b/src/EDI/Reader.php
@@ -11,9 +11,9 @@ namespace EDI;
 class Reader
 {
     /**
-     * @var array parsed EDI file
+     * @var Parser Holding parsed EDI file
      */
-    private $parsedfile;
+    private $parser;
 
     /**
      * @var array<int,string>
@@ -22,14 +22,12 @@ class Reader
 
     /**
      * Reader constructor.
-     *
-     * @param string $url url or path ur EDI message
+     * @param Parser $parser With a message already loaded.
      */
-    public function __construct(string $url = null)
+    public function __construct(Parser $parser)
     {
-        if (isset($url)) {
-            $this->load($url);
-        }
+        $this->parser = $parser;
+        $this->preValidate();
     }
 
     /**
@@ -53,37 +51,12 @@ class Reader
     }
 
     /**
-     * Returns the parsed file contained within.
-     *
+     * Returns the parsed message.
      * @returns array
      */
     public function getParsedFile(): array
     {
-        return $this->parsedfile;
-    }
-
-    /**
-     * @param string $location URL or path to EDI file/message
-     * @return bool
-     */
-    public function load(string $location): bool
-    {
-        $parser = new Parser();
-        $parser->load($location)->parse();
-
-        return $this->setParsedFile($parser->get());
-    }
-
-    /**
-     * @param array $parsed_file
-     *
-     * @return bool
-     */
-    public function setParsedFile(array $parsed_file): bool
-    {
-        $this->parsedfile = $parsed_file;
-
-        return $this->preValidate();
+        return $this->parser->get();
     }
 
     /**
@@ -95,7 +68,7 @@ class Reader
     {
         $this->errors = [];
 
-        if (!\is_array($this->parsedfile)) {
+        if (!\is_array($this->getParsedFile())) {
             $this->errors[] = 'Incorrect format parsed file';
 
             return false;
@@ -217,7 +190,7 @@ class Reader
         }
 
         // search segments which conform to filter
-        foreach ($this->parsedfile as $edi_row) {
+        foreach ($this->getParsedFile() as $edi_row) {
             if ($edi_row[0] == $segment_name) {
                 if ($filter_elements) {
                     foreach ($filter_elements as $el_id => $el_value) {
@@ -448,7 +421,7 @@ class Reader
         $group = [];
         $position = 'before_search';
 
-        foreach ($this->parsedfile as $edi_row) {
+        foreach ($this->getParsedFile() as $edi_row) {
             // search before group segment
             if ($position == 'before_search' && $edi_row[0] == $before) {
                 $position = 'before_is';

--- a/tests/EDITest/AnalyserTest.php
+++ b/tests/EDITest/AnalyserTest.php
@@ -63,9 +63,11 @@ final class AnalyserTest extends TestCase
 
     public function testProcess()
     {
-        $parser = new Parser(__DIR__ . '/../files/example.edi');
-        $parsed = $parser->get();
+        $parser = new Parser();
+        $parser->load(__DIR__ . '/../files/example.edi');
         $segments = $parser->getRawSegments();
+        $parser->parse();
+        $parsed = $parser->get();
         static::assertCount(15, $parsed);
         $result = (new Analyser())->process($parsed, $segments);
 
@@ -74,9 +76,11 @@ final class AnalyserTest extends TestCase
 
     public function testProcessWrapped()
     {
-        $parser = new Parser(__DIR__ . '/../files/example_wrapped.edi');
-        $parsed = $parser->get();
+        $parser = new Parser();
+        $parser->load(__DIR__ . '/../files/example_wrapped.edi');
         $segments = $parser->getRawSegments();
+        $parser->parse();
+        $parsed = $parser->get();
         static::assertCount(15, $parsed);
         $result = (new Analyser())->process($parsed, $segments);
         static::assertSame(399, \strlen($result));

--- a/tests/EDITest/InterpreterTest.php
+++ b/tests/EDITest/InterpreterTest.php
@@ -13,7 +13,8 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
 {
     public function testCOARRI()
     {
-        $parser = new Parser(__DIR__ . '/../files/D95BCOARRI.edi');
+        $parser = new Parser();
+        $parser->load(__DIR__ . '/../files/D95BCOARRI.edi')->parse();
 
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
@@ -31,7 +32,8 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
 
     public function testServiceSegments()
     {
-        $parser = new Parser(__DIR__ . '/../files/D95BCOARRI.edi');
+        $parser = new Parser();
+        $parser->load(__DIR__ . '/../files/D95BCOARRI.edi')->parse();
 
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
@@ -50,7 +52,8 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
 
     public function testBAPLIE()
     {
-        $parser = new Parser(__DIR__ . '/../files/D95BBAPLIE.edi');
+        $parser = new Parser();
+        $parser->load(__DIR__ . '/../files/D95BBAPLIE.edi')->parse();
 
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
@@ -70,7 +73,8 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
 
     public function testDESADV()
     {
-        $parser = new Parser(__DIR__ . '/../files/D96ADESADV.edi');
+        $parser = new Parser();
+        $parser->load(__DIR__ . '/../files/D96ADESADV.edi')->parse();
 
         $mapping = new \EDI\Mapping\MappingProvider('D96A');
         $analyser = new Analyser();
@@ -99,7 +103,8 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
     public function testMissingUNTUNZ()
     {
         $edi = "UNB+UNOA:2+LBCTI:01+OOCLIES:ZZ+160414:0307+1865'UNH+1907+BAPLIE:D:95B:UN:SMDG20'BGM++391651645'";
-        $parser = new Parser($edi);
+        $parser = new Parser();
+        $parser->loadString($edi)->parse();
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
@@ -119,8 +124,8 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
 
     public function testOrderError()
     {
-        $edi = \file_get_contents(__DIR__ . '/../files/example_order_error.edi');
-        $parser = new Parser($edi);
+        $parser = new Parser();
+        $parser->load(__DIR__ . '/../files/example_order_error.edi')->parse();
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
@@ -166,7 +171,8 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
     public function testOrderOk()
     {
         $edi = \file_get_contents(__DIR__ . '/../files/example_order_ok.edi');
-        $parser = new Parser($edi);
+        $parser = new Parser();
+        $parser->loadString($edi)->parse();
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
@@ -202,7 +208,8 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
     public function testMissingUNBUNH()
     {
         $edi = "UNT+30+1907'UNZ+1+1865'";
-        $parser = new Parser($edi);
+        $parser = new Parser();
+        $parser->loadString($edi)->parse();
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
@@ -223,7 +230,8 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
     public function testTooManyElements()
     {
         $edi = "UNB+UNOA:2+LBCTI:01+OOCLIES:ZZ:AA:DD+160414:0307+1865'UNZ+1+1865+TEST+TEST'";
-        $parser = new Parser($edi);
+        $parser = new Parser();
+        $parser->loadString($edi)->parse();
         $mapping = new \EDI\Mapping\MappingProvider('D95B');
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());
@@ -239,8 +247,8 @@ final class InterpreterTest extends \PHPUnit\Framework\TestCase
 
     public function testIdInsteadOfName()
     {
-        $edi = \file_get_contents(__DIR__ . '/../files/D96ADESADV.edi');
-        $parser = new Parser($edi);
+        $parser = new Parser();
+        $parser->load(__DIR__ . '/../files/D96ADESADV.edi')->parse();
         $mapping = new \EDI\Mapping\MappingProvider($parser->getMessageDirectory());
         $analyser = new Analyser();
         $segs = $analyser->loadSegmentsXml($mapping->getSegments());

--- a/tests/EDITest/ParserTest.php
+++ b/tests/EDITest/ParserTest.php
@@ -218,6 +218,7 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
         $arr = ["UNH+1452515553811+COARRI:D:95B:UN:ITG13'"];
         $p = new Parser();
         $p->loadArray($arr)->parse();
+        static::assertSame('1452515553811', $p->getMessageNumber());
         static::assertSame('COARRI', $p->getMessageFormat());
         static::assertSame('95B', $p->getMessageDirectory());
     }

--- a/tests/EDITest/ParserTest.php
+++ b/tests/EDITest/ParserTest.php
@@ -227,6 +227,7 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
         $arr = ["UNH+1452515553811+COARRI'"];
         $p = new Parser();
         $p->loadArray($arr)->parse();
+        static::assertSame('1452515553811', $p->getMessageNumber());
         static::assertSame('COARRI', $p->getMessageFormat());
         static::assertNull($p->getMessageDirectory());
     }

--- a/tests/EDITest/ReaderTest.php
+++ b/tests/EDITest/ReaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EDITest;
 
 use EDI\Reader;
+use EDI\Parser;
 
 /**
  * @internal
@@ -13,7 +14,9 @@ final class ReaderTest extends \PHPUnit\Framework\TestCase
 {
     public function testReadEdiDataValue()
     {
-        $r = new Reader(__DIR__ . '/../files/example.edi');
+        $p = new Parser();
+        $p->load(__DIR__ . '/../files/example.edi');
+        $r = new Reader($p);
 
         $sender = $r->readEdiDataValue('UNB', 2);
         static::assertSame('6XPPC', $sender);
@@ -27,37 +30,55 @@ final class ReaderTest extends \PHPUnit\Framework\TestCase
 
     public function testReadUNBDateTimeOfPpreperation()
     {
-        $Dt = (new Reader(__DIR__ . '/../files/example.edi'))->readUNBDateTimeOfPreparation();
+        $p = new Parser();
+        $p->load(__DIR__ . '/../files/example.edi');
+        $r = new Reader($p);
+        $Dt = $r->readUNBDateTimeOfPreparation();
         static::assertSame('2094-01-01 09:50:00', $Dt);
     }
 
     public function testReadUNBDateTimeOfPreperation()
     {
-        $Dt = (new Reader(__DIR__ . '/../files/example.edi'))->readUNBDateTimeOfPreparation();
+        $p = new Parser();
+        $p->load(__DIR__ . '/../files/example.edi');
+        $r = new Reader($p);
+        $Dt = $r->readUNBDateTimeOfPreparation();
         static::assertSame('2094-01-01 09:50:00', $Dt);
     }
 
     public function testReadUNBDateTimeOfPreparation()
     {
-        $Dt = (new Reader(__DIR__ . '/../files/example.edi'))->readUNBDateTimeOfPreparation();
+        $p = new Parser();
+        $p->load(__DIR__ . '/../files/example.edi');
+        $r = new Reader($p);
+        $Dt = $r->readUNBDateTimeOfPreparation();
         static::assertSame('2094-01-01 09:50:00', $Dt);
     }
 
     public function testReadUNHmessageType()
     {
-        $messageType = (new Reader(__DIR__ . '/../files/example.edi'))->readUNHmessageType();
+        $p = new Parser();
+        $p->load(__DIR__ . '/../files/example.edi');
+        $r = new Reader($p);
+        $messageType = $r->readUNHmessageType();
         static::assertSame('PAORES', $messageType);
     }
 
     public function testReadUNHmessageNumber()
     {
-        $messageNumber = (new Reader(__DIR__ . '/../files/example.edi'))->readUNHmessageNumber();
+        $p = new Parser();
+        $p->load(__DIR__ . '/../files/example.edi');
+        $r = new Reader($p);
+        $messageNumber = $r->readUNHmessageNumber();
         static::assertSame('1', $messageNumber);
     }
 
     public function testpreValidate()
     {
-        $errors = (new Reader(__DIR__ . '/../files/exampleMulti.edi'))->errors();
+        $p = new Parser();
+        $p->load(__DIR__ . '/../files/exampleMulti.edi');
+        $r = new Reader($p);
+        $errors = $r->errors();
         static::assertArrayHasKey(0, $errors);
 
         static::assertSame('File has multiple messages', $errors[0]);
@@ -69,11 +90,15 @@ final class ReaderTest extends \PHPUnit\Framework\TestCase
         $eddies = Reader::splitMultiMessage($multiEdi);
         static::assertCount(2, $eddies);
 
-        $r = new Reader($eddies[0]);
+        $p = new Parser();
+        $p->loadString($eddies[0]);
+        $r = new Reader($p);
         $messageType = $r->readUNHmessageType();
         static::assertSame('PAORES', $messageType);
 
-        $r = new Reader($eddies[1]);
+        $p = new Parser();
+        $p->loadString($eddies[1]);
+        $r = new Reader($p);
         $messageType = $r->readUNHmessageType();
         static::assertSame('PAORES', $messageType);
     }


### PR DESCRIPTION
See https://www.gefeg.com/jswg/cl/v3/11b/cl1.htm Those are all that are supported in syntax version 3. In v4 there are more: https://www.gefeg.com/jswg/cl/v4x/40219/cl1.htm

As discussed in #82 here's my suggested solution.

I think the check for UNOA and UNOB isn't 100% correct, but it was the best I could find.

The `if(!isset(self::$charsets[$this->syntaxID]))` check might be better as an entry in the `errors` array instead of an exception, but then the actual check wouldn't make any sense, if a different syntaxID is used. Maybe an `EdifactException`?

Also some minor refactoring, like renaming private stuff to be closer to what they are actually called in EDI lingo.

P.S.: I wouldn't return anything from either `load()`, `loadString()` or `parse()`. I consider that leaking object state. Especially since `get()` exists.