### PR TITLE
Loading extracted groups back in caused error

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -65,7 +65,7 @@ $reader = new EDI\Reader($parser);
 $groups = $reader->groupsExtract('INV');
 
 foreach ($groups as $record) {
-    $parser->loadArray($record);
+    $parser->loadArray($record, false);
     $r = EDI\Reader($parser);
     $records[] = [
         'storageLocation' => $r->readEdiDataValue(['LOC', ['2.0' => 'YA']], 2, 3),

--- a/README.md
+++ b/README.md
@@ -477,11 +477,11 @@ See section about EDI\Parser above on how to load a file into a parser.
 
 Errors
 ```php
-$c->errors();
+$r->errors();
 ```
 Array
 ```php
-$c->getParsedFile();
+$r->getParsedFile();
 ```
 
 EDI\Interpreter

--- a/src/EDI/Parser.php
+++ b/src/EDI/Parser.php
@@ -341,19 +341,26 @@ class Parser
         return $this;
     }
 
-	/**
-     * Load the message from an array of strings.
+    /**
+     * Load a raw or parsed message from an array of strings.
      * @param array $lines
+     * @param bool  $raw If the data hasn't been parsed yet
      * @return self
-	 */
-	public function loadArray(array $lines): self
+     */
+    public function loadArray(array $lines, bool $raw = true): self
 	{
-        $this->resetUNA();
-        $this->resetUNB();
-        $this->rawSegments = $lines;
-        if (\count($lines) === 1) {
-			$this->loadString($lines[0]);
-		}
+        if($raw) {
+            $this->resetUNA();
+            $this->resetUNB();
+            $this->rawSegments = $lines;
+            if (\count($lines) === 1) {
+                $this->loadString($lines[0]);
+            }
+        } else {
+            $this->rawSegments = [];
+            $this->parsedfile = $lines;
+        }
+
         return $this;
 	}
 

--- a/src/EDI/Reader.php
+++ b/src/EDI/Reader.php
@@ -492,13 +492,13 @@ class Reader
     }
 
     /**
-     * Get groups from message when last segment is unknown but you know the barrier
-     * useful for invoices by default.
+     * Get groups from message when last segment is unknown but you know the barrier.
+     * Useful for invoices by default.
      *
      * @param string                  $start   first segment start a new group
      * @param array<array-key,string> $barrier barrier segment (NOT in group)
      *
-     * @return array<mixed>
+     * @return array Containing parsed lines
      */
     public function groupsExtract(string $start = 'LIN', array $barrier = ['UNS']): array
     {
@@ -511,8 +511,7 @@ class Reader
             $segment = $edi_row[0];
             if (
                 $position == 'group_is'
-                &&
-                (
+                && (
                     $segment == $start
                     ||
                     \in_array($segment, $barrier, true)

--- a/tests/EDITest/ParserTest.php
+++ b/tests/EDITest/ParserTest.php
@@ -42,6 +42,16 @@ final class ParserTest extends \PHPUnit\Framework\TestCase
         static::assertSame($expected, $p->get());
     }
 
+    public function testArrayParsed()
+    {
+        $arr = [['LOC', '11', 'ITGOA'], ['MEA', 'WT', '', ['KGM', '9040']]];
+        $p = new Parser();
+        $p->loadArray($arr,false)->parse();
+
+        $expected = [['LOC', '11', 'ITGOA'], ['MEA', 'WT', '', ['KGM', '9040']]];
+        static::assertSame($expected, $p->get());
+    }
+
     public function testGetRawSegments()
     {
         $txt = "LOC+11+ITGOA'MEA+WT++KGM:9040'";


### PR DESCRIPTION
But passing an already parsed array means that the `rawSegments` won't be available, because it might not even be a valid EDI message that was passed. So it's kinda inconsistent state in the Parser.