### PR TITLE
Extend error message for syntax errors

### DIFF
--- a/src/EDI/Interpreter.php
+++ b/src/EDI/Interpreter.php
@@ -479,6 +479,8 @@ class Interpreter
         if ($segmentIdx != \count($message)) {
             $errors[] = [
                 'text' => $this->messageTextConf['NOTCONFORMANT'],
+                'position' => $segmentIdx,
+                'segmentId' => $message[$segmentIdx][0],
             ];
         }
 


### PR DESCRIPTION
The position and segmentID fields are added to the NOTCONFORMANT error message, in a similar manner as for the other error message types