### PR TITLE
Public getter for encoding + error message extensions

### DIFF
--- a/src/EDI/Interpreter.php
+++ b/src/EDI/Interpreter.php
@@ -479,6 +479,8 @@ class Interpreter
         if ($segmentIdx != \count($message)) {
             $errors[] = [
                 'text' => $this->messageTextConf['NOTCONFORMANT'],
+                'position' => $segmentIdx,
+                'segmentId' => $message[$segmentIdx][0],
             ];
         }
 

--- a/src/EDI/Parser.php
+++ b/src/EDI/Parser.php
@@ -284,7 +284,7 @@ class Parser
         }
 
         if (! isset(self::$charsets[$this->syntaxID])) {
-            throw new \RuntimeException('Unsupported syntax identifier');
+            throw new \RuntimeException('Unsupported syntax identifier: ' . $this->syntaxID);
         }
 
         return mb_check_encoding($this->parsedfile, self::$charsets[$this->syntaxID]);
@@ -326,6 +326,24 @@ class Parser
     public function getRawSegments(): array
     {
         return $this->rawSegments;
+    }
+
+    /**
+     * Get character encoding extracted from UNB header
+     *
+     * @return string
+     */
+    public function getCharset(): string
+    {
+        if (empty($this->parsedfile)) {
+            throw new \RuntimeException('No text has been parsed yet');
+        }
+
+        if (! isset(self::$charsets[$this->syntaxID])) {
+            throw new \RuntimeException('Unsupported syntax identifier: ' . $this->syntaxID);
+        }
+
+        return self::$charsets[$this->syntaxID];
     }
 
     /**


### PR DESCRIPTION
Public getter function implemented, returning the content encoding, with the same pre-checks as in the ```checkEncoding()``` function. Additionally a few more details are logged when parsing of a file stops due to syntax violation.