### PR TITLE
fix: concatenation of details instead of overwrite if its the same attribute

### DIFF
--- a/src/EDI/Analyser.php
+++ b/src/EDI/Analyser.php
@@ -223,7 +223,12 @@ class Analyser
                                 $r[] = '        '.\wordwrap($d_sub_desc_attr['desc'], 69, \PHP_EOL.'        ');
                                 $r[] = '        type: '.$d_sub_desc_attr['type'];
 
-                                $jsoncomposite[$d_sub_desc_attr['name']] = $d_detail;
+                                if (isset($jsoncomposite[$d_sub_desc_attr['name']])) {
+                                    $jsoncomposite[$d_sub_desc_attr['name']] .= $d_detail;
+                                } else {
+                                    $jsoncomposite[$d_sub_desc_attr['name']] = $d_detail;
+                                }
+
                                 if (isset($d_sub_desc_attr['maxlength'])) {
                                     $r[] = '        maxlen: '.$d_sub_desc_attr['maxlength'];
                                 }


### PR DESCRIPTION
## What?
[86949g88u](https://app.clickup.com/t/86949g88u) Concatenation instead of overwrite if same attribute
## Why?
In instances where the string has `:`, it is being segmented into different values in array, and only the last segment is being used as the value.
## How?
Concatenate the string if the attribute already exist instead of overwrite.