### PR TITLE
Resolves #150

### DIFF
--- a/src/EDI/Parser.php
+++ b/src/EDI/Parser.php
@@ -276,7 +276,10 @@ class Parser
         }
 
         $this->messageFormat = $lineElement[0];
-        $this->messageDirectory = $lineElement[2];
+
+        if (isset($lineElement[2])) {
+            $this->messageDirectory = $lineElement[2];
+        }
     }
 
     /**


### PR DESCRIPTION
This PR introduces a non-intrusive handling of issue #150 which states that a PHP warning (`Undefined array key`) is issued during parsing in some cases (presumably when parsing non-standard UN/EDIFACT data).